### PR TITLE
Code for MQTT Communication via ESP32 to AWS, uses Mutual Auth

### DIFF
--- a/Phase 1[Basic Communication Setup]/Challenges.md
+++ b/Phase 1[Basic Communication Setup]/Challenges.md
@@ -1,7 +1,8 @@
 ## Challenges Faced
 1. TLS Connection not setting up between ESP32 and AWS IoT Core, Certificate Parse error related stuff, Trying with inbuilt examples of ESP-IDF
+2. Including certificates issue with the ESP-IDF Code
 ---
 
 ## Solutions Tried
-
+2. CmakeLists.txt was not correct, took inspiration from ESP-IDF Examples for MQTT Mutual Auth
 ---

--- a/Phase 1[Basic Communication Setup]/Testing_Scripts/CMakeLists.txt
+++ b/Phase 1[Basic Communication Setup]/Testing_Scripts/CMakeLists.txt
@@ -1,0 +1,12 @@
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS components/esp-aws-iot)
+
+project(aws_iot_test)
+target_add_binary_data(${CMAKE_PROJECT_NAME}.elf "main/certificates/client.crt" TEXT)
+target_add_binary_data(${CMAKE_PROJECT_NAME}.elf "main/certificates/client.key" TEXT)
+target_add_binary_data(${CMAKE_PROJECT_NAME}.elf "main/certificates/server.crt" TEXT)

--- a/Phase 1[Basic Communication Setup]/Testing_Scripts/aws_iot_test.c
+++ b/Phase 1[Basic Communication Setup]/Testing_Scripts/aws_iot_test.c
@@ -1,0 +1,90 @@
+#include <stdio.h>
+#include <string.h>
+#include "esp_log.h"
+#include "esp_wifi.h"
+#include "mqtt_client.h"
+#include "esp_event.h"
+#include "nvs_flash.h"
+
+extern const uint8_t client_cert_pem_start[] asm("_binary_client_crt_start");
+extern const uint8_t client_cert_pem_end[] asm("_binary_client_crt_end");
+
+extern const uint8_t client_key_pem_start[] asm("_binary_client_key_start");
+extern const uint8_t client_key_pem_end[] asm("_binary_client_key_end");
+
+extern const uint8_t server_cert_pem_start[] asm("_binary_server_crt_start");
+extern const uint8_t server_cert_pem_end[] asm("_binary_server_crt_end");
+
+// Configuration - Update these values!
+#define WIFI_SSID "elecom-061db7"
+#define WIFI_PASS "dvxfmhn42xy5"
+#define AWS_IOT_ENDPOINT "a3mq2067foq75p-ats.iot.us-east-1.amazonaws.com"
+#define TOPIC "test/topic"
+#define MESSAGE "Hello from ESP32"
+
+static void wifi_init(void) {
+    esp_netif_init();
+    esp_event_loop_create_default();
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_wifi_init(&cfg);
+
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = WIFI_SSID,
+            .password = WIFI_PASS,
+        },
+    };
+
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    esp_wifi_set_config(WIFI_IF_STA, &wifi_config);
+    esp_wifi_start();
+    esp_wifi_connect();
+}
+
+// Corrected MQTT Event Handler
+static void mqtt_event_handler_cb(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data) {
+    esp_mqtt_event_handle_t event = event_data;
+    esp_mqtt_client_handle_t client = event->client;
+
+    switch ((esp_mqtt_event_id_t)event_id) {
+    case MQTT_EVENT_CONNECTED:
+        esp_mqtt_client_publish(client, TOPIC, MESSAGE, 0, 1, 0);
+        ESP_LOGI("MQTT", "Published message: %s", MESSAGE);
+        break;
+    case MQTT_EVENT_DISCONNECTED:
+        ESP_LOGI("MQTT", "Disconnected from AWS IoT Core");
+        break;
+    default:
+        break;
+    }
+}
+
+// Corrected MQTT Initialization
+static void mqtt_app_start(void) {
+    const esp_mqtt_client_config_t mqtt_cfg = {
+        .broker.address.uri = "mqtts://" AWS_IOT_ENDPOINT,
+        .broker.verification.certificate = (const char *)server_cert_pem_start,
+        .credentials = {
+      .authentication = {
+        .certificate = (const char *)client_cert_pem_start,
+        .key = (const char *)client_key_pem_start,
+            },
+        }
+    };
+    esp_mqtt_client_handle_t client = esp_mqtt_client_init(&mqtt_cfg);
+    esp_mqtt_client_register_event(client, ESP_EVENT_ANY_ID, mqtt_event_handler_cb, NULL);
+    esp_mqtt_client_start(client);
+}
+
+void app_main(void) {
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+    wifi_init();
+    mqtt_app_start();
+}


### PR DESCRIPTION
Fixes Issue #1 , used certificates to setup TLS connection, successfully verified message publish to test/topic in AWS MQTT Client